### PR TITLE
Add coupdaybs(), coupdays(), coupdaysnc() functions (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Tiers 1-3 are complete.
 - **Tier 3:** ✓rri, ✓pduration, ✓vdb, ✓fvschedule, ✓dollarde, ✓dollarfr, ✓ispmt
 - **Tier 4:** ✓yield, ✓price, duration, mduration, disc, intrate, received,
   pricedisc, pricemat, yielddisc, yieldmat
-- **Tier 5:** all others
+- **Tier 5:** ✓coupdaybs, ✓coupdays, ✓coupdaysnc, all others
 
 ## License
 

--- a/src/coupdaybs.js
+++ b/src/coupdaybs.js
@@ -1,0 +1,64 @@
+import {
+  coupdaybs as coupdaybsUtil,
+  getCouponBounds,
+  toUtcDate,
+} from "./util.js";
+
+/**
+ * Returns the number of days from the beginning of the coupon period to the
+ * settlement date.
+ *
+ * Remarks:
+ * - `settlement`, `maturity`, `frequency`, and `basis` are truncated to
+ *   integers.
+ * - If `settlement` or `maturity` is not a valid date, an error is thrown.
+ * - If `frequency` is any number other than `1`, `2`, or `4`, an error is
+ *   thrown.
+ * - If `basis` < `0` or if `basis` > `4`, an error is thrown.
+ * - If `settlement` >= `maturity`, an error is thrown.
+ *
+ * @param {Date} settlement - The security's settlement date.
+ * @param {Date} maturity - The security's maturity date.
+ * @param {1|2|4} frequency - The number of coupon payments per year. For annual
+ * payments, frequency = `1`; for semiannual, frequency = `2`; for quarterly,
+ * frequency = `4`.
+ * @param {0|1|2|3|4} [basis=0] - The type of day count basis to use. `0` or
+ * omitted = US (NASD 30/360), `1` = actual/actual, `2` = actual/360, `3` =
+ * actual/365, `4` = European 30/360.
+ * @returns {number} The number of days from the beginning of the coupon period
+ * to the settlement date.
+ *
+ * @example
+ * coupdaybs(new Date("2011-01-25"), new Date("2011-11-15"), 2, 1); // 71
+ */
+export function coupdaybs(settlement, maturity, frequency, basis = 0) {
+  const settlementDate = toUtcDate(settlement);
+  const maturityDate = toUtcDate(maturity);
+
+  frequency = /** @type {1|2|4} */ (Math.trunc(frequency));
+  const basisNumber = Math.trunc(basis ?? 0);
+
+  if (![1, 2, 4].includes(frequency)) {
+    throw new RangeError("Invalid frequency.");
+  }
+
+  if (basisNumber < 0 || basisNumber > 4) {
+    throw new RangeError("Invalid basis.");
+  }
+
+  /** @type {0|1|2|3|4} */
+  const normalizedBasis = /** @type {0|1|2|3|4} */ (basisNumber);
+
+  if (settlementDate >= maturityDate) {
+    throw new RangeError("Settlement must be before maturity.");
+  }
+
+  const monthsPerCoupon = 12 / frequency;
+  const { previousCouponDate } = getCouponBounds(
+    settlementDate,
+    maturityDate,
+    monthsPerCoupon,
+  );
+
+  return coupdaybsUtil(previousCouponDate, settlementDate, normalizedBasis);
+}

--- a/src/coupdays.js
+++ b/src/coupdays.js
@@ -1,0 +1,69 @@
+import {
+  coupdays as coupdaysUtil,
+  getCouponBounds,
+  toUtcDate,
+} from "./util.js";
+
+/**
+ * Returns the number of days in the coupon period that contains the settlement
+ * date.
+ *
+ * Remarks:
+ * - `settlement`, `maturity`, `frequency`, and `basis` are truncated to
+ *   integers.
+ * - If `settlement` or `maturity` is not a valid date, an error is thrown.
+ * - If `frequency` is any number other than `1`, `2`, or `4`, an error is
+ *   thrown.
+ * - If `basis` < `0` or if `basis` > `4`, an error is thrown.
+ * - If `settlement` >= `maturity`, an error is thrown.
+ *
+ * @param {Date} settlement - The security's settlement date.
+ * @param {Date} maturity - The security's maturity date.
+ * @param {1|2|4} frequency - The number of coupon payments per year. For annual
+ * payments, frequency = `1`; for semiannual, frequency = `2`; for quarterly,
+ * frequency = `4`.
+ * @param {0|1|2|3|4} [basis=0] - The type of day count basis to use. `0` or
+ * omitted = US (NASD 30/360), `1` = actual/actual, `2` = actual/360, `3` =
+ * actual/365, `4` = European 30/360.
+ * @returns {number} The number of days in the coupon period that contains the
+ * settlement date.
+ *
+ * @example
+ * coupdays(new Date("2011-01-25"), new Date("2011-11-15"), 2, 1); // 184
+ */
+export function coupdays(settlement, maturity, frequency, basis = 0) {
+  const settlementDate = toUtcDate(settlement);
+  const maturityDate = toUtcDate(maturity);
+
+  frequency = /** @type {1|2|4} */ (Math.trunc(frequency));
+  const basisNumber = Math.trunc(basis ?? 0);
+
+  if (![1, 2, 4].includes(frequency)) {
+    throw new RangeError("Invalid frequency.");
+  }
+
+  if (basisNumber < 0 || basisNumber > 4) {
+    throw new RangeError("Invalid basis.");
+  }
+
+  /** @type {0|1|2|3|4} */
+  const normalizedBasis = /** @type {0|1|2|3|4} */ (basisNumber);
+
+  if (settlementDate >= maturityDate) {
+    throw new RangeError("Settlement must be before maturity.");
+  }
+
+  const monthsPerCoupon = 12 / frequency;
+  const { previousCouponDate, nextCouponDate } = getCouponBounds(
+    settlementDate,
+    maturityDate,
+    monthsPerCoupon,
+  );
+
+  return coupdaysUtil(
+    previousCouponDate,
+    nextCouponDate,
+    frequency,
+    normalizedBasis,
+  );
+}

--- a/src/coupdaysnc.js
+++ b/src/coupdaysnc.js
@@ -1,0 +1,63 @@
+import {
+  coupdaysnc as coupdaysncUtil,
+  getCouponBounds,
+  toUtcDate,
+} from "./util.js";
+
+/**
+ * Returns the number of days from the settlement date to the next coupon date.
+ *
+ * Remarks:
+ * - `settlement`, `maturity`, `frequency`, and `basis` are truncated to
+ *   integers.
+ * - If `settlement` or `maturity` is not a valid date, an error is thrown.
+ * - If `frequency` is any number other than `1`, `2`, or `4`, an error is
+ *   thrown.
+ * - If `basis` < `0` or if `basis` > `4`, an error is thrown.
+ * - If `settlement` >= `maturity`, an error is thrown.
+ *
+ * @param {Date} settlement - The security's settlement date.
+ * @param {Date} maturity - The security's maturity date.
+ * @param {1|2|4} frequency - The number of coupon payments per year. For annual
+ * payments, frequency = `1`; for semiannual, frequency = `2`; for quarterly,
+ * frequency = `4`.
+ * @param {0|1|2|3|4} [basis=0] - The type of day count basis to use. `0` or
+ * omitted = US (NASD 30/360), `1` = actual/actual, `2` = actual/360, `3` =
+ * actual/365, `4` = European 30/360.
+ * @returns {number} The number of days from the settlement date to the next
+ * coupon date.
+ *
+ * @example
+ * coupdaysnc(new Date("2011-01-25"), new Date("2011-11-15"), 2, 1); // 113
+ */
+export function coupdaysnc(settlement, maturity, frequency, basis = 0) {
+  const settlementDate = toUtcDate(settlement);
+  const maturityDate = toUtcDate(maturity);
+
+  frequency = /** @type {1|2|4} */ (Math.trunc(frequency));
+  const basisNumber = Math.trunc(basis ?? 0);
+
+  if (![1, 2, 4].includes(frequency)) {
+    throw new RangeError("Invalid frequency.");
+  }
+
+  if (basisNumber < 0 || basisNumber > 4) {
+    throw new RangeError("Invalid basis.");
+  }
+
+  /** @type {0|1|2|3|4} */
+  const normalizedBasis = /** @type {0|1|2|3|4} */ (basisNumber);
+
+  if (settlementDate >= maturityDate) {
+    throw new RangeError("Settlement must be before maturity.");
+  }
+
+  const monthsPerCoupon = 12 / frequency;
+  const { nextCouponDate } = getCouponBounds(
+    settlementDate,
+    maturityDate,
+    monthsPerCoupon,
+  );
+
+  return coupdaysncUtil(settlementDate, nextCouponDate, normalizedBasis);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+export { coupdaybs } from "./coupdaybs.js";
+export { coupdays } from "./coupdays.js";
+export { coupdaysnc } from "./coupdaysnc.js";
 export { cumipmt } from "./cumipmt.js";
 export { cumprinc } from "./cumprinc.js";
 export { db } from "./db.js";

--- a/src/price.js
+++ b/src/price.js
@@ -1,4 +1,5 @@
 import {
+  actualDays,
   coupdaybs,
   coupdays,
   coupdaysnc,
@@ -108,12 +109,16 @@ export function price(
 
   const a = coupdaybs(previousCouponDate, settlementDate, normalizedBasis);
   let dsc = coupdaysnc(settlementDate, nextCouponDate, normalizedBasis);
-  const e = coupdays(
+  let e = coupdays(
     previousCouponDate,
     nextCouponDate,
     frequency,
     normalizedBasis,
   );
+
+  if (normalizedBasis === 2) {
+    e = actualDays(previousCouponDate, nextCouponDate);
+  }
 
   if (normalizedBasis === 3) {
     dsc = e - a;

--- a/src/util.js
+++ b/src/util.js
@@ -283,7 +283,7 @@ export function coupdaybs(previousCouponDate, settlementDate, basis) {
  * coupdays(new Date("2024-01-01"), new Date("2024-07-01"), 2, 3); // 182.5
  */
 export function coupdays(previousCouponDate, nextCouponDate, frequency, basis) {
-  if (basis === 0 || basis === 4) {
+  if (basis === 0 || basis === 2 || basis === 4) {
     return 360 / frequency;
   }
 

--- a/src/yield_.js
+++ b/src/yield_.js
@@ -1,4 +1,5 @@
 import {
+  actualDays,
   coupdaybs,
   coupdays,
   coupdaysnc,
@@ -108,12 +109,16 @@ export function yield_(
 
   const a = coupdaybs(previousCouponDate, settlementDate, normalizedBasis);
   let dsc = coupdaysnc(settlementDate, nextCouponDate, normalizedBasis);
-  const e = coupdays(
+  let e = coupdays(
     previousCouponDate,
     nextCouponDate,
     frequency,
     normalizedBasis,
   );
+
+  if (normalizedBasis === 2) {
+    e = actualDays(previousCouponDate, nextCouponDate);
+  }
 
   if (normalizedBasis === 3) {
     dsc = e - a;

--- a/test/coupdaybs.test.js
+++ b/test/coupdaybs.test.js
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import { coupdaybs } from "../src/coupdaybs.js";
+
+test.each(
+  /** @type {[Date, Date, 1|2|4, 0|1|2|3|4 | undefined, number][]} */ ([
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 1, 71],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 0, 70],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 2, 71],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 3, 71],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 4, 70],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 1, 0, 70],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 4, 0, 70],
+    [new Date("2026-04-10"), new Date("2027-06-15"), 4, 1, 26],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, undefined, 70],
+  ]),
+)(
+  "coupdaybs() matches Excel to 8 decimal places",
+  (settlement, maturity, frequency, basis, expected) => {
+    expect(
+      coupdaybs(settlement, maturity, frequency, basis),
+    ).toBeCloseTo(expected, 8);
+  },
+);
+
+test.each(
+  /** @type {[Date, Date, 1|2|4, 0|1|2|3|4 | undefined][]} */ ([
+    [new Date("invalid"), new Date("2026-11-15"), 2, 0],
+    [new Date("2026-01-25"), new Date("invalid"), 2, 0],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 3, 0],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, -1],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 5],
+    [new Date("2026-11-15"), new Date("2026-11-15"), 2, 0],
+    [new Date("2027-01-01"), new Date("2026-11-15"), 2, 0],
+  ]),
+)(
+  "coupdaybs() throws RangeError for invalid inputs",
+  (settlement, maturity, frequency, basis) => {
+    expect(() =>
+      coupdaybs(settlement, maturity, frequency, basis),
+    ).toThrow(RangeError);
+  },
+);

--- a/test/coupdaybs.test.js
+++ b/test/coupdaybs.test.js
@@ -16,9 +16,10 @@ test.each(
 )(
   "coupdaybs() matches Excel to 8 decimal places",
   (settlement, maturity, frequency, basis, expected) => {
-    expect(
-      coupdaybs(settlement, maturity, frequency, basis),
-    ).toBeCloseTo(expected, 8);
+    expect(coupdaybs(settlement, maturity, frequency, basis)).toBeCloseTo(
+      expected,
+      8,
+    );
   },
 );
 
@@ -35,8 +36,8 @@ test.each(
 )(
   "coupdaybs() throws RangeError for invalid inputs",
   (settlement, maturity, frequency, basis) => {
-    expect(() =>
-      coupdaybs(settlement, maturity, frequency, basis),
-    ).toThrow(RangeError);
+    expect(() => coupdaybs(settlement, maturity, frequency, basis)).toThrow(
+      RangeError,
+    );
   },
 );

--- a/test/coupdays.test.js
+++ b/test/coupdays.test.js
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+import { coupdays } from "../src/coupdays.js";
+
+test.each(
+  /** @type {[Date, Date, 1|2|4, 0|1|2|3|4 | undefined, number][]} */ ([
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 1, 181],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 0, 180],
+    // BUG: basis=2 returns actual days (181) instead of 360/frequency (180).
+    // Root cause is in util.js:coupdays — also affects price() and yield_().
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 2, 181],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 3, 182.5],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 4, 180],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 1, 0, 360],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 4, 0, 90],
+    [new Date("2026-04-10"), new Date("2027-06-15"), 4, 1, 92],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, undefined, 180],
+  ]),
+)(
+  "coupdays() matches Excel to 8 decimal places",
+  (settlement, maturity, frequency, basis, expected) => {
+    expect(
+      coupdays(settlement, maturity, frequency, basis),
+    ).toBeCloseTo(expected, 8);
+  },
+);
+
+test.each(
+  /** @type {[Date, Date, 1|2|4, 0|1|2|3|4 | undefined][]} */ ([
+    [new Date("invalid"), new Date("2026-11-15"), 2, 0],
+    [new Date("2026-01-25"), new Date("invalid"), 2, 0],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 3, 0],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, -1],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 5],
+    [new Date("2026-11-15"), new Date("2026-11-15"), 2, 0],
+    [new Date("2027-01-01"), new Date("2026-11-15"), 2, 0],
+  ]),
+)(
+  "coupdays() throws RangeError for invalid inputs",
+  (settlement, maturity, frequency, basis) => {
+    expect(() =>
+      coupdays(settlement, maturity, frequency, basis),
+    ).toThrow(RangeError);
+  },
+);

--- a/test/coupdays.test.js
+++ b/test/coupdays.test.js
@@ -5,9 +5,7 @@ test.each(
   /** @type {[Date, Date, 1|2|4, 0|1|2|3|4 | undefined, number][]} */ ([
     [new Date("2026-01-25"), new Date("2026-11-15"), 2, 1, 181],
     [new Date("2026-01-25"), new Date("2026-11-15"), 2, 0, 180],
-    // BUG: basis=2 returns actual days (181) instead of 360/frequency (180).
-    // Root cause is in util.js:coupdays — also affects price() and yield_().
-    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 2, 181],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 2, 180],
     [new Date("2026-01-25"), new Date("2026-11-15"), 2, 3, 182.5],
     [new Date("2026-01-25"), new Date("2026-11-15"), 2, 4, 180],
     [new Date("2026-01-25"), new Date("2026-11-15"), 1, 0, 360],
@@ -18,9 +16,10 @@ test.each(
 )(
   "coupdays() matches Excel to 8 decimal places",
   (settlement, maturity, frequency, basis, expected) => {
-    expect(
-      coupdays(settlement, maturity, frequency, basis),
-    ).toBeCloseTo(expected, 8);
+    expect(coupdays(settlement, maturity, frequency, basis)).toBeCloseTo(
+      expected,
+      8,
+    );
   },
 );
 
@@ -37,8 +36,8 @@ test.each(
 )(
   "coupdays() throws RangeError for invalid inputs",
   (settlement, maturity, frequency, basis) => {
-    expect(() =>
-      coupdays(settlement, maturity, frequency, basis),
-    ).toThrow(RangeError);
+    expect(() => coupdays(settlement, maturity, frequency, basis)).toThrow(
+      RangeError,
+    );
   },
 );

--- a/test/coupdaysnc.test.js
+++ b/test/coupdaysnc.test.js
@@ -16,9 +16,10 @@ test.each(
 )(
   "coupdaysnc() matches Excel to 8 decimal places",
   (settlement, maturity, frequency, basis, expected) => {
-    expect(
-      coupdaysnc(settlement, maturity, frequency, basis),
-    ).toBeCloseTo(expected, 8);
+    expect(coupdaysnc(settlement, maturity, frequency, basis)).toBeCloseTo(
+      expected,
+      8,
+    );
   },
 );
 
@@ -35,8 +36,8 @@ test.each(
 )(
   "coupdaysnc() throws RangeError for invalid inputs",
   (settlement, maturity, frequency, basis) => {
-    expect(() =>
-      coupdaysnc(settlement, maturity, frequency, basis),
-    ).toThrow(RangeError);
+    expect(() => coupdaysnc(settlement, maturity, frequency, basis)).toThrow(
+      RangeError,
+    );
   },
 );

--- a/test/coupdaysnc.test.js
+++ b/test/coupdaysnc.test.js
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import { coupdaysnc } from "../src/coupdaysnc.js";
+
+test.each(
+  /** @type {[Date, Date, 1|2|4, 0|1|2|3|4 | undefined, number][]} */ ([
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 1, 110],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 0, 110],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 2, 110],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 3, 110],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 4, 110],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 1, 0, 290],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 4, 0, 20],
+    [new Date("2026-04-10"), new Date("2027-06-15"), 4, 1, 66],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, undefined, 110],
+  ]),
+)(
+  "coupdaysnc() matches Excel to 8 decimal places",
+  (settlement, maturity, frequency, basis, expected) => {
+    expect(
+      coupdaysnc(settlement, maturity, frequency, basis),
+    ).toBeCloseTo(expected, 8);
+  },
+);
+
+test.each(
+  /** @type {[Date, Date, 1|2|4, 0|1|2|3|4 | undefined][]} */ ([
+    [new Date("invalid"), new Date("2026-11-15"), 2, 0],
+    [new Date("2026-01-25"), new Date("invalid"), 2, 0],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 3, 0],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, -1],
+    [new Date("2026-01-25"), new Date("2026-11-15"), 2, 5],
+    [new Date("2026-11-15"), new Date("2026-11-15"), 2, 0],
+    [new Date("2027-01-01"), new Date("2026-11-15"), 2, 0],
+  ]),
+)(
+  "coupdaysnc() throws RangeError for invalid inputs",
+  (settlement, maturity, frequency, basis) => {
+    expect(() =>
+      coupdaysnc(settlement, maturity, frequency, basis),
+    ).toThrow(RangeError);
+  },
+);


### PR DESCRIPTION
Public wrappers over existing util.js helpers
Tests validated against Google Sheets https://docs.google.com/spreadsheets/d/151fvM7NkYqOBtwibCg1sf0uGn-LEEFpyyPHbQ9_B9vU/edit?usp=sharing.
Note: basis=2 test in coupdays is conditionally valid (see #40).