### PR TITLE
Add `mduration()` function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export { ipmt } from "./ipmt.js";
 export { irr } from "./irr.js";
 export { ispmt } from "./ispmt.js";
 export { mirr } from "./mirr.js";
+export { mduration } from "./mduration.js";
 export { nominal } from "./nominal.js";
 export { nper } from "./nper.js";
 export { npv } from "./npv.js";

--- a/src/mduration.js
+++ b/src/mduration.js
@@ -1,0 +1,49 @@
+import { normalizeZero } from "./util.js";
+import { duration } from "./duration.js";
+
+/**
+ * Returns the modified Macauley duration for a security with an assumed par
+ * value of $100.
+ *
+ * Modified duration is defined as:
+ * ```
+ * MDURATION = DURATION / (1 + yld / frequency)
+ * ```
+ *
+ * Remarks:
+ * - `settlement`, `maturity`, `frequency`, and `basis` are truncated to
+ *   integers.
+ * - If `settlement` or `maturity` is not a valid date, an error is thrown.
+ * - If `coupon` < `0` or if `yld` < `0`, an error is thrown.
+ * - If `frequency` is any number other than `1`, `2`, or `4`, an error is
+ *   thrown.
+ * - If `basis` < `0` or if `basis` > `4`, an error is thrown.
+ * - If `settlement` >= `maturity`, an error is thrown.
+ *
+ * @param {Date} settlement - The security's settlement date.
+ * @param {Date} maturity - The security's maturity date.
+ * @param {number} coupon - The security's annual coupon rate.
+ * @param {number} yld - The security's annual yield.
+ * @param {1|2|4} frequency - The number of coupon payments per year. For
+ * annual payments, frequency = `1`; for semiannual, frequency = `2`; for
+ * quarterly, frequency = `4`.
+ * @param {0|1|2|3|4} [basis=0] - The type of day count basis to use. `0` or
+ * omitted = US (NASD 30/360), `1` = actual/actual, `2` = actual/360, `3` =
+ * actual/365, `4` = European 30/360.
+ * @returns {number} The modified Macauley duration.
+ *
+ * @example
+ * mduration(new Date("2008-01-01"), new Date("2016-01-01"), 0.08, 0.09, 2, 1); // 5.73566981
+ */
+export function mduration(
+  settlement,
+  maturity,
+  coupon,
+  yld,
+  frequency,
+  basis = 0,
+) {
+  const macDur = duration(settlement, maturity, coupon, yld, frequency, basis);
+
+  return normalizeZero(macDur / (1 + yld / frequency));
+}

--- a/test/mduration.test.js
+++ b/test/mduration.test.js
@@ -1,0 +1,100 @@
+import { expect, test } from "vitest";
+import { mduration } from "../src/mduration.js";
+
+test.each(
+  /** @type {[Date, Date, number, number, 1|2|4, 0|1|2|3|4 | undefined, number][]} */ ([
+    // Microsoft example from docs
+    [
+      new Date("2008-01-01"),
+      new Date("2016-01-01"),
+      0.08,
+      0.09,
+      2,
+      1,
+      5.73566981,
+    ],
+    // Annual coupon
+    [
+      new Date("2020-01-01"),
+      new Date("2030-01-01"),
+      0.05,
+      0.06,
+      1,
+      0,
+      7.56842797,
+    ],
+    // Semiannual, US 30/360
+    [
+      new Date("2008-02-15"),
+      new Date("2017-11-15"),
+      0.0575,
+      0.065,
+      2,
+      0,
+      7.18303603,
+    ],
+    // Quarterly, actual/actual
+    [
+      new Date("2022-06-15"),
+      new Date("2032-06-15"),
+      0.045,
+      0.04,
+      4,
+      1,
+      8.07219173,
+    ],
+    // Actual/360 basis
+    [
+      new Date("2021-03-31"),
+      new Date("2026-03-31"),
+      0.06,
+      0.055,
+      2,
+      2,
+      4.28298592,
+    ],
+    // Actual/365 basis
+    [
+      new Date("2019-09-01"),
+      new Date("2029-09-01"),
+      0.035,
+      0.037,
+      2,
+      3,
+      8.35333045,
+    ],
+    // European 30/360
+    [
+      new Date("2018-12-15"),
+      new Date("2023-12-15"),
+      0.055,
+      0.06,
+      4,
+      4,
+      4.33224395,
+    ],
+    // Default basis (undefined -> 0)
+    [
+      new Date("2025-01-01"),
+      new Date("2035-01-01"),
+      0.04,
+      0.05,
+      2,
+      undefined,
+      8.05423106,
+    ],
+  ]),
+)(
+  "mduration(%s, %s, %s, %s, %s, %s) should return %s",
+  (settlement, maturity, coupon, yld, frequency, basis, expected) => {
+    const result = mduration(
+      settlement,
+      maturity,
+      coupon,
+      yld,
+      frequency,
+      basis,
+    );
+    expect(result).toBeCloseTo(expected, 2);
+  },
+);


### PR DESCRIPTION
Adds an exported function called `duration()` which calculates the modified Macauley duration for a security with an assumed par value of $100.

Closes #46 